### PR TITLE
Add flags to enable remote fetching and raw HTML output

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,6 +32,15 @@ const Options = {
     preformattedCode: ['false', 'true']
 };
 
+async function fetchContentFromUrl(url, playwright) {
+    const browser = await playwright.chromium.launch();
+    const page = await browser.newPage();
+    await page.goto(url);
+    const content = await page.content();
+    await browser.close();
+    return content;
+}
+
 var argv = Minimist(process.argv.slice(2));
 
 if (argv.h || argv.help) {
@@ -70,6 +79,8 @@ Options:
                   ${serialize(Options.linkReferenceStyle)}
   -p --pre        Preformatted code
                   ${serialize(Options.preformattedCode)}
+  -m --remote     Enable remote fetching
+  -w --raw        Save raw HTML content
 
 Note that the first choice is default for each options.
 
@@ -78,6 +89,8 @@ Examples:
   turndown-cli sample.html
   turndown-cli sample.html sample.md
   turndown-cli -t=2 -r=3 -c=2 -f=1 -s=2 sample.html
+  turndown-cli -m http://www.example.com
+  turndown-cli -mw http://www.example.com
     `);
 } else if (argv.v || argv.version) {
     console.log(`
@@ -89,108 +102,251 @@ Licensed under MIT License
 } else {
     var sourcePath = argv._[0];
     if (!!sourcePath) {
-        sourcePath = path.resolve(sourcePath);
-        let targetFilename = path.basename(sourcePath, path.extname(sourcePath)) + '.md';
-        var defaultTargetPath = path.join(path.dirname(sourcePath), targetFilename);
-        var targetPath = argv._[1] || defaultTargetPath;
-
-        var options = {};
-
-        if (argv.head || argv.t) {
-            let optVal = argv.head || argv.t;
-            optVal = +optVal - 1;
-            if (optVal < Options.headingStyle.length) {
-                options.headingStyle = Options.headingStyle[optVal];
-            }
-        }
-        if (argv.hr || argv.r) {
-            let optVal = argv.hr || argv.r;
-            optVal = +optVal - 1;
-            if (optVal < Options.hr.length) {
-                options.hr = Options.hr[optVal];
-            }
-        }
-        if (argv.bullet || argv.b) {
-            let optVal = argv.bullet || argv.b;
-            optVal = +optVal - 1;
-            if (optVal < Options.bulletListMarker.length) {
-                options.bulletListMarker = Options.bulletListMarker[optVal];
-            }
-        }
-        if (argv.code || argv.c) {
-            let optVal = argv.code || argv.c;
-            optVal = +optVal - 1;
-            if (optVal < Options.codeBlockStyle.length) {
-                options.codeBlockStyle = Options.codeBlockStyle[optVal];
-            }
-        }
-        if (argv.fence || argv.f) {
-            let optVal = argv.fence || argv.f;
-            optVal = +optVal - 1;
-            if (optVal < Options.fence.length) {
-                options.fence = Options.fence[optVal];
-            }
-        }
-        if (argv.em || argv.e) {
-            let optVal = argv.em || argv.e;
-            optVal = +optVal - 1;
-            if (optVal < Options.emDelimiter.length) {
-                options.emDelimiter = Options.emDelimiter[optVal];
-            }
-        }
-        if (argv.strong || argv.s) {
-            let optVal = argv.strong || argv.s;
-            optVal = +optVal - 1;
-            if (optVal < Options.strongDelimiter.length) {
-                options.strongDelimiter = Options.strongDelimiter[optVal];
-            }
-        }
-        if (argv.link || argv.l) {
-            let optVal = argv.link || argv.l;
-            optVal = +optVal - 1;
-            if (optVal < Options.linkStyle.length) {
-                options.linkStyle = Options.linkStyle[optVal];
-            }
-        }
-        if (argv.linkref || argv.u) {
-            let optVal = argv.linkref || argv.u;
-            optVal = +optVal - 1;
-            if (optVal < Options.linkReferenceStyle.length) {
-                options.linkReferenceStyle = Options.linkReferenceStyle[optVal];
-            }
-        }
-        if (argv.pre || argv.p) {
-            let optVal = argv.pre || argv.p;
-            optVal = +optVal - 1;
-            if (optVal < Options.preformattedCode.length) {
-                options.preformattedCode = Options.preformattedCode[optVal];
-            }
-        }
-
-        var turndownService = new TurndownService(options);
-
-        fs.readFile(sourcePath, 'utf8', (err, data) => {
-            if (err) {
-                console.error(err);
-                return;
-            }
-            try {
-                var markdown = turndownService.turndown(data);
-            } catch (e) {
-                console.log(`Error: Something went wrong while conversion.`, e);
-            }
-            if (!!markdown) {
-                fs.writeFile(targetPath, markdown, err => {
-                    if (err) {
-                        console.err(err);
-                        return;
-                    }
-                    console.log(`Saved at path
+        if (argv.m || argv.remote) {
+            if (sourcePath.startsWith('http://') || sourcePath.startsWith('https://')) {
+                (async () => {
+                    const playwright = await import('playwright');
+                    const content = await fetchContentFromUrl(sourcePath, playwright);
+                    if (argv.raw || argv.w) {
+                        let targetFilename = path.basename(sourcePath, path.extname(sourcePath)) + '.html';
+                        var defaultTargetPath = path.join(process.cwd(), targetFilename);
+                        var targetPath = argv._[1] || defaultTargetPath;
+                        fs.writeFile(targetPath, content, err => {
+                            if (err) {
+                                console.error(err);
+                                return;
+                            }
+                            console.log(`Raw HTML saved at path
   Relative: ${path.relative(process.cwd(), targetPath)}
   Absolute: ${targetPath}`);
-                })
+                        });
+                    } else {
+                        var turndownService = new TurndownService();
+                        var markdown = turndownService.turndown(content);
+                        let targetFilename = path.basename(sourcePath, path.extname(sourcePath)) + '.md';
+                        var defaultTargetPath = path.join(process.cwd(), targetFilename);
+                        var targetPath = argv._[1] || defaultTargetPath;
+                        fs.writeFile(targetPath, markdown, err => {
+                            if (err) {
+                                console.error(err);
+                                return;
+                            }
+                            console.log(`Markdown saved at path
+  Relative: ${path.relative(process.cwd(), targetPath)}
+  Absolute: ${targetPath}`);
+                        });
+                    }
+                })().catch(error => {
+                    console.error('Error fetching content:', error);
+                });
+            } else {
+                sourcePath = path.resolve(sourcePath);
+                let targetFilename = path.basename(sourcePath, path.extname(sourcePath)) + '.md';
+                var defaultTargetPath = path.join(path.dirname(sourcePath), targetFilename);
+                var targetPath = argv._[1] || defaultTargetPath;
+
+                var options = {};
+
+                if (argv.head || argv.t) {
+                    let optVal = argv.head || argv.t;
+                    optVal = +optVal - 1;
+                    if (optVal < Options.headingStyle.length) {
+                        options.headingStyle = Options.headingStyle[optVal];
+                    }
+                }
+                if (argv.hr || argv.r) {
+                    let optVal = argv.hr || argv.r;
+                    optVal = +optVal - 1;
+                    if (optVal < Options.hr.length) {
+                        options.hr = Options.hr[optVal];
+                    }
+                }
+                if (argv.bullet || argv.b) {
+                    let optVal = argv.bullet || argv.b;
+                    optVal = +optVal - 1;
+                    if (optVal < Options.bulletListMarker.length) {
+                        options.bulletListMarker = Options.bulletListMarker[optVal];
+                    }
+                }
+                if (argv.code || argv.c) {
+                    let optVal = argv.code || argv.c;
+                    optVal = +optVal - 1;
+                    if (optVal < Options.codeBlockStyle.length) {
+                        options.codeBlockStyle = Options.codeBlockStyle[optVal];
+                    }
+                }
+                if (argv.fence || argv.f) {
+                    let optVal = argv.fence || argv.f;
+                    optVal = +optVal - 1;
+                    if (optVal < Options.fence.length) {
+                        options.fence = Options.fence[optVal];
+                    }
+                }
+                if (argv.em || argv.e) {
+                    let optVal = argv.em || argv.e;
+                    optVal = +optVal - 1;
+                    if (optVal < Options.emDelimiter.length) {
+                        options.emDelimiter = Options.emDelimiter[optVal];
+                    }
+                }
+                if (argv.strong || argv.s) {
+                    let optVal = argv.strong || argv.s;
+                    optVal = +optVal - 1;
+                    if (optVal < Options.strongDelimiter.length) {
+                        options.strongDelimiter = Options.strongDelimiter[optVal];
+                    }
+                }
+                if (argv.link || argv.l) {
+                    let optVal = argv.link || argv.l;
+                    optVal = +optVal - 1;
+                    if (optVal < Options.linkStyle.length) {
+                        options.linkStyle = Options.linkStyle[optVal];
+                    }
+                }
+                if (argv.linkref || argv.u) {
+                    let optVal = argv.linkref || argv.u;
+                    optVal = +optVal - 1;
+                    if (optVal < Options.linkReferenceStyle.length) {
+                        options.linkReferenceStyle = Options.linkReferenceStyle[optVal];
+                    }
+                }
+                if (argv.pre || argv.p) {
+                    let optVal = argv.pre || argv.p;
+                    optVal = +optVal - 1;
+                    if (optVal < Options.preformattedCode.length) {
+                        options.preformattedCode = Options.preformattedCode[optVal];
+                    }
+                }
+
+                var turndownService = new TurndownService(options);
+
+                fs.readFile(sourcePath, 'utf8', (err, data) => {
+                    if (err) {
+                        console.error(err);
+                        return;
+                    }
+                    try {
+                        var markdown = turndownService.turndown(data);
+                    } catch (e) {
+                        console.log(`Error: Something went wrong while conversion.`, e);
+                    }
+                    if (!!markdown) {
+                        fs.writeFile(targetPath, markdown, err => {
+                            if (err) {
+                                console.error(err);
+                                return;
+                            }
+                            console.log(`Markdown saved at path
+  Relative: ${path.relative(process.cwd(), targetPath)}
+  Absolute: ${targetPath}`);
+                        });
+                    }
+                });
             }
-        });
+        } else {
+            sourcePath = path.resolve(sourcePath);
+            let targetFilename = path.basename(sourcePath, path.extname(sourcePath)) + '.md';
+            var defaultTargetPath = path.join(path.dirname(sourcePath), targetFilename);
+            var targetPath = argv._[1] || defaultTargetPath;
+
+            var options = {};
+
+            if (argv.head || argv.t) {
+                let optVal = argv.head || argv.t;
+                optVal = +optVal - 1;
+                if (optVal < Options.headingStyle.length) {
+                    options.headingStyle = Options.headingStyle[optVal];
+                }
+            }
+            if (argv.hr || argv.r) {
+                let optVal = argv.hr || argv.r;
+                optVal = +optVal - 1;
+                if (optVal < Options.hr.length) {
+                    options.hr = Options.hr[optVal];
+                }
+            }
+            if (argv.bullet || argv.b) {
+                let optVal = argv.bullet || argv.b;
+                optVal = +optVal - 1;
+                if (optVal < Options.bulletListMarker.length) {
+                    options.bulletListMarker = Options.bulletListMarker[optVal];
+                }
+            }
+            if (argv.code || argv.c) {
+                let optVal = argv.code || argv.c;
+                optVal = +optVal - 1;
+                if (optVal < Options.codeBlockStyle.length) {
+                    options.codeBlockStyle = Options.codeBlockStyle[optVal];
+                }
+            }
+            if (argv.fence || argv.f) {
+                let optVal = argv.fence || argv.f;
+                optVal = +optVal - 1;
+                if (optVal < Options.fence.length) {
+                    options.fence = Options.fence[optVal];
+                }
+            }
+            if (argv.em || argv.e) {
+                let optVal = argv.em || argv.e;
+                optVal = +optVal - 1;
+                if (optVal < Options.emDelimiter.length) {
+                    options.emDelimiter = Options.emDelimiter[optVal];
+                }
+            }
+            if (argv.strong || argv.s) {
+                let optVal = argv.strong || argv.s;
+                optVal = +optVal - 1;
+                if (optVal < Options.strongDelimiter.length) {
+                    options.strongDelimiter = Options.strongDelimiter[optVal];
+                }
+            }
+            if (argv.link || argv.l) {
+                let optVal = argv.link || argv.l;
+                optVal = +optVal - 1;
+                if (optVal < Options.linkStyle.length) {
+                    options.linkStyle = Options.linkStyle[optVal];
+                }
+            }
+            if (argv.linkref || argv.u) {
+                let optVal = argv.linkref || argv.u;
+                optVal = +optVal - 1;
+                if (optVal < Options.linkReferenceStyle.length) {
+                    options.linkReferenceStyle = Options.linkReferenceStyle[optVal];
+                }
+            }
+            if (argv.pre || argv.p) {
+                let optVal = argv.pre || argv.p;
+                optVal = +optVal - 1;
+                if (optVal < Options.preformattedCode.length) {
+                    options.preformattedCode = Options.preformattedCode[optVal];
+                }
+            }
+
+            var turndownService = new TurndownService(options);
+
+            fs.readFile(sourcePath, 'utf8', (err, data) => {
+                if (err) {
+                    console.error(err);
+                    return;
+                }
+                try {
+                    var markdown = turndownService.turndown(data);
+                } catch (e) {
+                    console.log(`Error: Something went wrong while conversion.`, e);
+                }
+                if (!!markdown) {
+                    fs.writeFile(targetPath, markdown, err => {
+                        if (err) {
+                            console.error(err);
+                            return;
+                        }
+                        console.log(`Markdown saved at path
+  Relative: ${path.relative(process.cwd(), targetPath)}
+  Absolute: ${targetPath}`);
+                    });
+                }
+            });
+        }
     } else {
         console.log(`Error: Missing 'source' filepath param`);
     }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "homepage": "https://github.com/isurfer21/turndown-cli#readme",
   "dependencies": {
     "minimist": "^1.2.5",
-    "turndown": "^7.0.0"
+    "turndown": "^7.0.0",
+    "playwright": "^1.30.0"
   },
   "bin": {
     "turndown-cli": "./index.js"


### PR DESCRIPTION
Note additions to the "Options" and "Examples" section when calling `turndown-cli -h`

```
$ turndown-cli -h
Usages:
  ...
Parameters:
  ...
Options:
  ...
  -m --remote     Enable remote fetching
  -w --raw        Save raw HTML content
  
Examples:
  ...
  turndown-cli -m http://www.example.com
  turndown-cli -mw http://www.example.com
```

